### PR TITLE
編集画面への遷移とコメント欄の遷移を変更

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,3 +56,7 @@ gem 'devise'
 gem 'mini_magick'
 gem 'image_processing', '~> 1.2'
 gem 'pry-rails'
+
+group :production do
+  gem 'rails_12factor'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,6 +148,11 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
+    rails_12factor (0.0.3)
+      rails_serve_static_assets
+      rails_stdout_logging
+    rails_serve_static_assets (0.0.5)
+    rails_stdout_logging (0.0.5)
     railties (6.0.3.4)
       actionpack (= 6.0.3.4)
       activesupport (= 6.0.3.4)
@@ -237,6 +242,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.11)
   rails (~> 6.0.0)
+  rails_12factor
   sass-rails (~> 5)
   selenium-webdriver
   spring

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -1,6 +1,6 @@
 class PrototypesController < ApplicationController
   before_action :authenticate_user!
-  before_action :move_to_index, only: [:edit]
+  before_action :set_prototype, only: [:edit]
   protect_from_forgery with: :null_session
 
   def index
@@ -27,6 +27,7 @@ class PrototypesController < ApplicationController
   end
   def edit
     @prototype = Prototype.find(params[:id])
+    move_to_index
   end
   def update
     prototype = Prototype.find(params[:id])
@@ -52,7 +53,7 @@ class PrototypesController < ApplicationController
     params.require(:prototype).permit(:title, :catch_copy, :concept, :image).merge(user_id: current_user.id)
   end
   def move_to_index
-    unless user_signed_in?
+    unless user_signed_in? && current_user.name == @prototype.user.id
       redirect_to action: :index
     end
   end

--- a/app/views/prototypes/show.html.erb
+++ b/app/views/prototypes/show.html.erb
@@ -50,7 +50,8 @@
              <%if @comments %>
                 <% @comments.each do |comment| %>
                   <%= comment.text %>
-                  <%= link_to comment.user.name, "/users/#{:id}", class: :comment_user %>
+
+                  <%= link_to comment.user.name, user_path(@prototype.user.id), class: :comment_user %>
                 <% end %>
               <% end %>
             </li>


### PR DESCRIPTION
what
コメント蘭のユーザー名のリンクが誤っていたため、修正しました。
edit画面のurlを直接入力すると投稿内容を修正できてしまう不具合を修正しました。

why
指摘事項
